### PR TITLE
Fix Synr to support TVMScript for TensorIR

### DIFF
--- a/synr/ast.py
+++ b/synr/ast.py
@@ -210,6 +210,9 @@ class Var(Expr):
         return Var(Span.invalid(), Id.invalid())
 
 
+Pattern = List[Var]
+
+
 @attr.s(auto_attribs=True, frozen=True)
 class Attr(Expr):
     """Field access on variable or structure or module.
@@ -595,7 +598,7 @@ class For(Stmt):
     and :code:`body` will be :code:`pass`.
     """
 
-    lhs: Union[Var, Tuple]
+    lhs: Pattern
     rhs: Expr
     body: Block
 
@@ -615,7 +618,7 @@ class With(Stmt):
     and :code:`body` will be :code:`pass`.
     """
 
-    lhs: Optional[Union[Var, ArrayLiteral, Tuple]]
+    lhs: Pattern
     rhs: Expr
     body: Block
 

--- a/synr/ast.py
+++ b/synr/ast.py
@@ -595,7 +595,7 @@ class For(Stmt):
     and :code:`body` will be :code:`pass`.
     """
 
-    lhs: Expr
+    lhs: Union[Var, Tuple]
     rhs: Expr
     body: Block
 
@@ -615,7 +615,7 @@ class With(Stmt):
     and :code:`body` will be :code:`pass`.
     """
 
-    lhs: Optional[Expr]
+    lhs: Optional[Union[Var, ArrayLiteral, Tuple]]
     rhs: Expr
     body: Block
 

--- a/synr/ast.py
+++ b/synr/ast.py
@@ -595,7 +595,7 @@ class For(Stmt):
     and :code:`body` will be :code:`pass`.
     """
 
-    lhs: Var
+    lhs: Expr
     rhs: Expr
     body: Block
 
@@ -615,7 +615,7 @@ class With(Stmt):
     and :code:`body` will be :code:`pass`.
     """
 
-    lhs: Optional[Var]
+    lhs: Optional[Expr]
     rhs: Expr
     body: Block
 

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -297,7 +297,7 @@ class Compiler:
                             lhs_vars.append(x)
                         else:
                             self.error(
-                                "Right hand side of with statement (y in `with x as y:`) must be a variable, list of var or tuple of var, but gets "
+                                "Right hand side of with statement (y in `with x as y:`) must be a variable, list of var or tuple of var, but it is "
                                 + str(type(x)),
                                 x.span,
                             )

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -264,7 +264,7 @@ class Compiler:
                 lhs_vars = [x for x in l.values if isinstance(x, Var)]
             else:
                 self.error(
-                    "Left hand side of for loop (the x in `for x in range(...)`) must be variables",
+                    "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables",
                     self.span_from_ast(stmt.target),
                 )
                 lhs_vars = [Var(Span.invalid(), Id.invalid())]

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -256,12 +256,6 @@ class Compiler:
 
         elif isinstance(stmt, py_ast.For):
             lhs = self.compile_expr(stmt.target)
-            if not isinstance(lhs, Var):
-                self.error(
-                    "Left hand side of for loop (the x in `for x in range(...)`) must be a single variable",
-                    self.span_from_ast(stmt.target),
-                )
-                lhs = Var(Span.invalid(), Id.invalid())
             rhs = self.compile_expr(stmt.iter)
             body = self.compile_block(stmt.body)
             return For(self.span_from_ast(stmt), lhs, rhs, body)
@@ -275,15 +269,7 @@ class Compiler:
             wth = stmt.items[0]
             lhs_var: Optional[Var]
             if wth.optional_vars:
-                l = self.compile_expr(wth.optional_vars)
-                if not isinstance(l, Var):
-                    self.error(
-                        "Right hand side of with statement (y in `with x as y:`) must be a variable",
-                        self.span_from_ast(wth.optional_vars),
-                    )
-                    lhs_var = Var.invalid()
-                else:
-                    lhs_var = l
+                lhs_var = self.compile_expr(wth.optional_vars)
             else:
                 lhs_var = None
             rhs = self.compile_expr(wth.context_expr)

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -256,6 +256,15 @@ class Compiler:
 
         elif isinstance(stmt, py_ast.For):
             lhs = self.compile_expr(stmt.target)
+            if not isinstance(lhs, Var) and (
+                not isinstance(lhs, Tuple)
+                or [x for x in lhs.values if not isinstance(x, Var)]
+            ):
+                self.error(
+                    "Left hand side of for loop (the x in `for x in range(...)`) must be variables",
+                    self.span_from_ast(stmt.target),
+                )
+                lhs = Var(Span.invalid(), Id.invalid())
             rhs = self.compile_expr(stmt.iter)
             body = self.compile_block(stmt.body)
             return For(self.span_from_ast(stmt), lhs, rhs, body)
@@ -267,9 +276,21 @@ class Compiler:
                     self.span_from_asts(stmt.items),
                 )
             wth = stmt.items[0]
-            lhs_var: Optional[Expr]
+            lhs_var: Optional[Union[Var, ArrayLiteral, Tuple]]
             if wth.optional_vars:
-                lhs_var = self.compile_expr(wth.optional_vars)
+                l = self.compile_expr(wth.optional_vars)
+                if isinstance(l, Var):
+                    lhs_var = l
+                elif (isinstance(l, ArrayLiteral) or isinstance(l, Tuple)) and not [
+                    x for x in l.values if not isinstance(x, Var)
+                ]:
+                    lhs_var = l
+                else:
+                    self.error(
+                        "Right hand side of with statement (y in `with x as y:`) must be a variable, list of var or tuple of var",
+                        self.span_from_ast(wth.optional_vars),
+                    )
+                    lhs_var = Var.invalid()
             else:
                 lhs_var = None
             rhs = self.compile_expr(wth.context_expr)

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -265,7 +265,7 @@ class Compiler:
                         lhs_vars.append(x)
                     else:
                         self.error(
-                            "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables, but <span class="x x-first x-last">it is</span> "
+                            "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables, but it is "
                             + str(type(x)),
                             x.span,
                         )

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -258,10 +258,17 @@ class Compiler:
             l = self.compile_expr(stmt.target)
             if isinstance(l, Var):
                 lhs_vars = [l]
-            elif isinstance(l, Tuple) and not [
-                x for x in l.values if not isinstance(x, Var)
-            ]:
-                lhs_vars = [x for x in l.values if isinstance(x, Var)]
+            elif isinstance(l, Tuple):
+                lhs_vars = []
+                for x in l.values:
+                    if isinstance(x, Var):
+                        lhs_vars.append(x)
+                    else:
+                        self.error(
+                            "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables, but gets "
+                            + str(type(x)),
+                            x.span,
+                        )
             else:
                 self.error(
                     "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables",
@@ -283,10 +290,17 @@ class Compiler:
                 l = self.compile_expr(wth.optional_vars)
                 if isinstance(l, Var):
                     lhs_vars = [l]
-                elif (isinstance(l, ArrayLiteral) or isinstance(l, Tuple)) and not [
-                    x for x in l.values if not isinstance(x, Var)
-                ]:
-                    lhs_vars = [x for x in l.values if isinstance(x, Var)]
+                elif isinstance(l, ArrayLiteral) or isinstance(l, Tuple):
+                    lhs_vars = []
+                    for x in l.values:
+                        if isinstance(x, Var):
+                            lhs_vars.append(x)
+                        else:
+                            self.error(
+                                "Right hand side of with statement (y in `with x as y:`) must be a variable, list of var or tuple of var, but gets "
+                                + str(type(x)),
+                                x.span,
+                            )
                 else:
                     self.error(
                         "Right hand side of with statement (y in `with x as y:`) must be a variable, list of var or tuple of var",

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -267,7 +267,7 @@ class Compiler:
                     self.span_from_asts(stmt.items),
                 )
             wth = stmt.items[0]
-            lhs_var: Optional[Var]
+            lhs_var: Optional[Expr]
             if wth.optional_vars:
                 lhs_var = self.compile_expr(wth.optional_vars)
             else:

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -265,7 +265,7 @@ class Compiler:
                         lhs_vars.append(x)
                     else:
                         self.error(
-                            "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables, but gets "
+                            "Left hand side of for loop (the x in `for x in range(...)`) must be one or more variables, but <span class="x x-first x-last">it is</span> "
                             + str(type(x)),
                             x.span,
                         )

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -64,6 +64,7 @@ def func_for():
     for x, y in grid(5, 6):
         return x
 
+
 def test_for():
     module = to_ast(func_for)
     fn = assert_one_fn(module, "func_for", no_params=0)

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -61,10 +61,13 @@ def func_for():
     for x in range(3):
         return x
 
+    for x, y in grid(5, 6):
+        return x
 
 def test_for():
     module = to_ast(func_for)
     fn = assert_one_fn(module, "func_for", no_params=0)
+
     fr = fn.body.stmts[0]
     assert isinstance(fr, synr.ast.For), "Did not find for loop"
     assert fr.lhs.id.name == "x", "For lhs is incorrect"
@@ -74,9 +77,24 @@ def test_for():
     assert isinstance(fr.body.stmts[0], synr.ast.Return)
     assert fr.body.stmts[0].value.id.name == "x"
 
+    fr = fn.body.stmts[1]
+    assert isinstance(fr, synr.ast.For), "Did not find for loop"
+    assert isinstance(fr.lhs, synr.ast.Tuple)
+    assert fr.lhs.values[0].id.name == "x", "For lhs is incorrect"
+    assert fr.lhs.values[1].id.name == "y", "For lhs is incorrect"
+    assert isinstance(fr.rhs, synr.ast.Call)
+    assert fr.rhs.func_name.id.name == "grid"
+    assert fr.rhs.params[0].value == 5
+    assert fr.rhs.params[1].value == 6
+    assert isinstance(fr.body.stmts[0], synr.ast.Return)
+    assert fr.body.stmts[0].value.id.name == "x"
+
 
 def func_with():
     with x as y:
+        return x
+
+    with block() as [x, y]:
         return x
 
 
@@ -89,6 +107,18 @@ def test_with():
     ), "Did not find With statement, found %s" % type(wth)
     assert wth.rhs.id.name == "x"
     assert wth.lhs.id.name == "y"
+    assert isinstance(wth.body.stmts[0], synr.ast.Return)
+    assert wth.body.stmts[0].value.id.name == "x"
+
+    wth = fn.body.stmts[1]
+    assert isinstance(
+        wth, synr.ast.With
+    ), "Did not find With statement, found %s" % type(wth)
+    assert isinstance(wth.rhs, synr.ast.Call)
+    assert wth.rhs.func_name.id.name == "block"
+    assert isinstance(wth.lhs, synr.ast.ArrayLiteral)
+    assert wth.lhs.values[0].id.name == "x"
+    assert wth.lhs.values[1].id.name == "y"
     assert isinstance(wth.body.stmts[0], synr.ast.Return)
     assert wth.body.stmts[0].value.id.name == "x"
 

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -71,7 +71,7 @@ def test_for():
 
     fr = fn.body.stmts[0]
     assert isinstance(fr, synr.ast.For), "Did not find for loop"
-    assert fr.lhs.id.name == "x", "For lhs is incorrect"
+    assert fr.lhs[0].id.name == "x", "For lhs is incorrect"
     assert isinstance(fr.rhs, synr.ast.Call)
     assert fr.rhs.func_name.id.name == "range"
     assert fr.rhs.params[0].value == 3
@@ -80,9 +80,9 @@ def test_for():
 
     fr = fn.body.stmts[1]
     assert isinstance(fr, synr.ast.For), "Did not find for loop"
-    assert isinstance(fr.lhs, synr.ast.Tuple)
-    assert fr.lhs.values[0].id.name == "x", "For lhs is incorrect"
-    assert fr.lhs.values[1].id.name == "y", "For lhs is incorrect"
+    assert len(fr.lhs) == 2
+    assert fr.lhs[0].id.name == "x", "For lhs is incorrect"
+    assert fr.lhs[1].id.name == "y", "For lhs is incorrect"
     assert isinstance(fr.rhs, synr.ast.Call)
     assert fr.rhs.func_name.id.name == "grid"
     assert fr.rhs.params[0].value == 5
@@ -101,6 +101,9 @@ def func_with():
     with block() as ():
         return True
 
+    with block():
+        return True
+
 
 def test_with():
     module = to_ast(func_with)
@@ -110,7 +113,7 @@ def test_with():
         wth, synr.ast.With
     ), "Did not find With statement, found %s" % type(wth)
     assert wth.rhs.id.name == "x"
-    assert wth.lhs.id.name == "y"
+    assert wth.lhs[0].id.name == "y"
     assert isinstance(wth.body.stmts[0], synr.ast.Return)
     assert wth.body.stmts[0].value.id.name == "x"
 
@@ -120,9 +123,9 @@ def test_with():
     ), "Did not find With statement, found %s" % type(wth)
     assert isinstance(wth.rhs, synr.ast.Call)
     assert wth.rhs.func_name.id.name == "block"
-    assert isinstance(wth.lhs, synr.ast.ArrayLiteral)
-    assert wth.lhs.values[0].id.name == "x"
-    assert wth.lhs.values[1].id.name == "y"
+    assert len(wth.lhs) == 2
+    assert wth.lhs[0].id.name == "x"
+    assert wth.lhs[1].id.name == "y"
     assert isinstance(wth.body.stmts[0], synr.ast.Return)
     assert wth.body.stmts[0].value.id.name == "x"
 
@@ -132,8 +135,7 @@ def test_with():
     ), "Did not find With statement, found %s" % type(wth)
     assert isinstance(wth.rhs, synr.ast.Call)
     assert wth.rhs.func_name.id.name == "block"
-    assert isinstance(wth.lhs, synr.ast.Tuple)
-    assert len(wth.lhs.values) == 0
+    assert len(wth.lhs) == 0
 
 
 def func_block():

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -98,6 +98,9 @@ def func_with():
     with block() as [x, y]:
         return x
 
+    with block() as ():
+        return True
+
 
 def test_with():
     module = to_ast(func_with)
@@ -122,6 +125,15 @@ def test_with():
     assert wth.lhs.values[1].id.name == "y"
     assert isinstance(wth.body.stmts[0], synr.ast.Return)
     assert wth.body.stmts[0].value.id.name == "x"
+
+    wth = fn.body.stmts[2]
+    assert isinstance(
+        wth, synr.ast.With
+    ), "Did not find With statement, found %s" % type(wth)
+    assert isinstance(wth.rhs, synr.ast.Call)
+    assert wth.rhs.func_name.id.name == "block"
+    assert isinstance(wth.lhs, synr.ast.Tuple)
+    assert len(wth.lhs.values) == 0
 
 
 def func_block():


### PR DESCRIPTION
In TensorIR, we have the following two cases, which is baned by synr before:

### tir.grid
```Python
for i, j, k in tir.grid(2, 3, 4):
```
which is the sugar for
```Python
for i in range(2):
    for j in range(3):
        for k in range(4):
```

### tir.block
```Python
with tir.block([128, 128], "C") as [vi, vj]:
     C[vi, vj] = B[vi, vj] + 1.0
```
in this case, we define two variables `vi` and `vj` in only one `with stmt`.

This PR is to fix Synr checking rules to prepare for TensorIR upstreaming.

cc @jroesch @tkonolige @junrushao1994 