### PR TITLE
Support parse inner scope function

### DIFF
--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -678,7 +678,9 @@ def to_ast(
             full_source = source
     diagnostic_ctx.add_source(source_name, full_source)
     program_ast = py_ast.parse(source)
-    compiler = Compiler(source_name, start_line, start_column, transformer, diagnostic_ctx)
+    compiler = Compiler(
+        source_name, start_line, start_column, transformer, diagnostic_ctx
+    )
     assert isinstance(program_ast, py_ast.Module), "Synr only supports module inputs"
     prog = compiler.compile_module(program_ast)
     err = diagnostic_ctx.render()

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -12,6 +12,7 @@ from .transformer import Transformer
 class Compiler:
     filename: str
     start_line: int
+    start_column: int
     transformer: Optional[Transformer]
     diagnostic_ctx: DiagnosticContext
 
@@ -43,11 +44,13 @@ class Compiler:
         self,
         filename: str,
         start_line: int,
+        start_column: int,
         transformer: Optional[Transformer],
         diagnostic_ctx: DiagnosticContext,
     ):
         self.filename = filename
         self.start_line = start_line - 1
+        self.start_column = start_column
         self.transformer = transformer
         self.diagnostic_ctx = diagnostic_ctx
 
@@ -79,9 +82,9 @@ class Compiler:
         return Span(
             span.filename,
             span.start_line + self.start_line,
-            span.start_column,
+            span.start_column + self.start_column,
             span.end_line + self.start_line,
-            span.end_column,
+            span.end_column + self.start_column,
         )
 
     def span_from_asts(self, nodes: Sequence[py_ast.AST]) -> Span:
@@ -656,11 +659,18 @@ def to_ast(
         source = program
         full_source = source
         start_line = 1
+        start_column = 0
     else:
         source_name = inspect.getsourcefile(program)  # type: ignore
         assert source_name, "source name must be valid"
         lines, start_line = inspect.getsourcelines(program)
-        source = "".join(lines)
+        start_column = 0
+        if len(lines) > 0:
+            start_column = len(lines[0]) - len(lines[0].lstrip())
+            if start_column == 0:
+                source = "".join(lines)
+            else:
+                source = "".join([l[start_column:] for l in lines])
         mod = inspect.getmodule(program)
         if mod is not None:
             full_source = inspect.getsource(mod)
@@ -668,7 +678,7 @@ def to_ast(
             full_source = source
     diagnostic_ctx.add_source(source_name, full_source)
     program_ast = py_ast.parse(source)
-    compiler = Compiler(source_name, start_line, transformer, diagnostic_ctx)
+    compiler = Compiler(source_name, start_line, start_column, transformer, diagnostic_ctx)
     assert isinstance(program_ast, py_ast.Module), "Synr only supports module inputs"
     prog = compiler.compile_module(program_ast)
     err = diagnostic_ctx.render()

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -502,8 +502,10 @@ def test_err_msg():
 
 def test_scoped_func():
     global_var = 0
+
     def func():
         return global_var
+
     module = to_ast(func)
     fn = assert_one_fn(module, "func", no_params=0)
     stmts = fn.body.stmts

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -500,6 +500,20 @@ def test_err_msg():
     assert errs[start + 2][0][1] == "Empty type assignment not supported"
 
 
+def test_scoped_func():
+    global_var = 0
+    def func():
+        return global_var
+    module = to_ast(func)
+    fn = assert_one_fn(module, "func", no_params=0)
+    stmts = fn.body.stmts
+    assert isinstance(stmts[0], synr.ast.Return)
+    assert stmts[0].value.id.name == "global_var"
+    _, start_line = inspect.getsourcelines(func)
+    assert stmts[0].span.start_line == start_line + 1
+    assert stmts[0].span.start_column == 9
+
+
 if __name__ == "__main__":
     test_id_function()
     test_class()
@@ -516,3 +530,4 @@ if __name__ == "__main__":
     test_call()
     test_constants()
     test_err_msg()
+    test_scoped_func()


### PR DESCRIPTION
Currently, parse a closure function in non-global scope will lead to indentation error.
```python
def some_process():
    def myfunc()
        pass
    sync.to_ast(myfunc, myprinter)
```
This PR try detect closure function by indentation of the first line. Then it wraps the code to make py_ast work normally, and lastly fixes the return structure.