### PR TITLE
support docstring in function

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-attrs
+attrs>=21.1.0

--- a/synr/ast.py
+++ b/synr/ast.py
@@ -519,7 +519,25 @@ class Assign(Stmt):
 
 
 @attr.s(auto_attribs=True, frozen=True)
-class UnassignedCall(Stmt):
+class UnassignedExpr(Stmt):
+    """A standalone expression.
+
+    Example
+    -------
+    .. code-block:: python
+
+        def my_function():
+            '''docstring'''
+            test_call()
+
+    Here :code:`'''docstring'''` and :code:`test_call()` is an :code:`UnassignedExpr`.
+    """
+
+    expr: Expr
+
+
+@attr.s(auto_attribs=True, frozen=True, init=False)
+class UnassignedCall(UnassignedExpr):
     """A standalone function call.
 
     Example
@@ -534,6 +552,9 @@ class UnassignedCall(Stmt):
     """
 
     call: Call
+
+    def __init__(self, span: Span, call: Call):
+        self.__attrs_init__(span, call, call)  # type: ignore
 
 
 @attr.s(auto_attribs=True, frozen=True)

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -330,11 +330,7 @@ class Compiler:
             if isinstance(expr, Call):
                 return UnassignedCall(expr.span, expr)
             else:
-                self.error(
-                    f"Found unexpected expression of type {type(expr)} when looking for a statement",
-                    expr.span,
-                )
-                return Stmt(Span.invalid())
+                return UnassignedExpr(expr.span, expr)
 
         elif isinstance(stmt, py_ast.Assert):
             return Assert(

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -516,6 +516,18 @@ def test_scoped_func():
     assert stmts[0].span.start_column == 9
 
 
+def test_docstring():
+    def func_withdoc():
+        """this function has a docstring"""
+        return 0
+
+    module = to_ast(func_withdoc)
+    fn = assert_one_fn(module, "func_withdoc", no_params=0)
+    stmts = fn.body.stmts
+    assert isinstance(stmts[0], synr.ast.UnassignedExpr)
+    assert stmts[0].expr.value == "this function has a docstring"
+
+
 if __name__ == "__main__":
     test_id_function()
     test_class()
@@ -533,3 +545,4 @@ if __name__ == "__main__":
     test_constants()
     test_err_msg()
     test_scoped_func()
+    test_docstring()


### PR DESCRIPTION
Support circumstances where the parsed function object contains a docstring. 
```python
def f():
   """this is a docstring"""
```

I think it can benefit users who follow some coding style convention for their functions get parsed. For example, in our circumstance pylint will complain about missing docstrings.

Currently if a non-call expr is not assigned to any var, the compiler will just report an error.  This change add an intermedia stmt node class `UnassignedExpr` and `UnassignedCall` then inherit from it.

BTW, i am not so familiar with attrs. Glad to see if there is better impl without lib attrs version requirements.

cc @tkonolige 



