### PR TITLE
Support parsing nonlocal and global

### DIFF
--- a/synr/ast.py
+++ b/synr/ast.py
@@ -537,6 +537,42 @@ class UnassignedCall(Stmt):
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class Nonlocal(Stmt):
+    """A nonlocal statement.
+
+    Example
+    -------
+    .. code-block:: python
+        x, y = 1, 2
+        def foo():
+            nonlocal x, y
+            return x
+
+    In :code:`nonlocal x, y`, :code:`vars` is :code`[x, y]`.
+    """
+
+    vars: List[Var]
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class Global(Stmt):
+    """A global statement.
+
+    Example
+    -------
+    .. code-block:: python
+        x, y = 1, 2
+        def foo():
+            global x, y
+            return x
+
+    In :code:`global x, y`, :code:`vars` is :code`[x, y]`.
+    """
+
+    vars: List[Var]
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class Block(Node):
     """A sequence of statements.
 

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -352,6 +352,16 @@ class Compiler:
                 None if stmt.msg is None else self.compile_expr(stmt.msg),
             )
 
+        elif isinstance(stmt, py_ast.Nonlocal):
+            return Nonlocal(
+                stmt_span, [Var(stmt_span, Id(stmt_span, name)) for name in stmt.names]
+            )
+
+        elif isinstance(stmt, py_ast.Global):
+            return Global(
+                stmt_span, [Var(stmt_span, Id(stmt_span, name)) for name in stmt.names]
+            )
+
         else:
             self.error(f"Found unexpected {type(stmt)} when compiling stmt", stmt_span)
             return Stmt(Span.invalid())

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -353,11 +353,15 @@ class Compiler:
             )
 
         elif isinstance(stmt, py_ast.Nonlocal):
+            # TODO: the variable spans here are incorrect as the Python AST stores each identifier
+            #       as a raw string (with no span information), so we just use the statement's span
             return Nonlocal(
                 stmt_span, [Var(stmt_span, Id(stmt_span, name)) for name in stmt.names]
             )
 
         elif isinstance(stmt, py_ast.Global):
+            # TODO: the variable spans here are incorrect as the Python AST stores each identifier
+            #       as a raw string (with no span information), so we just use the statement's span
             return Global(
                 stmt_span, [Var(stmt_span, Id(stmt_span, name)) for name in stmt.names]
             )

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -572,6 +572,38 @@ def test_decorators():
     assert bar.decorators[1].span.start_line == start_line + 3
 
 
+def test_nonlocal():
+    x, y = 1, 2
+
+    def foo():
+        nonlocal x, y
+        return x + y
+
+    module = to_ast(foo)
+    fn = assert_one_fn(module, "foo")
+    nl = fn.body.stmts[0]
+    assert isinstance(nl, synr.ast.Nonlocal)
+    assert len(nl.vars) == 2
+    x, y = nl.vars
+    assert isinstance(x, synr.ast.Var) and x.id.name == "x"
+    assert isinstance(y, synr.ast.Var) and y.id.name == "y"
+
+
+def test_global():
+    def foo():
+        global x, y
+        return x + y
+
+    module = to_ast(foo)
+    fn = assert_one_fn(module, "foo")
+    gl = fn.body.stmts[0]
+    assert isinstance(gl, synr.ast.Global)
+    assert len(gl.vars) == 2
+    x, y = gl.vars
+    assert isinstance(x, synr.ast.Var) and x.id.name == "x"
+    assert isinstance(y, synr.ast.Var) and y.id.name == "y"
+
+
 if __name__ == "__main__":
     test_id_function()
     test_class()
@@ -589,3 +621,7 @@ if __name__ == "__main__":
     test_constants()
     test_err_msg()
     test_scoped_func()
+    test_local_func()
+    test_decorators()
+    test_nonlocal()
+    test_global()

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -588,6 +588,10 @@ def test_nonlocal():
     assert isinstance(x, synr.ast.Var) and x.id.name == "x"
     assert isinstance(y, synr.ast.Var) and y.id.name == "y"
 
+    _, start_line = inspect.getsourcelines(foo)
+    assert nl.span.start_line == start_line + 1
+    # NOTE: variable spans are a bit hacky so we don't check them here
+
 
 def test_global():
     def foo():
@@ -602,6 +606,9 @@ def test_global():
     x, y = gl.vars
     assert isinstance(x, synr.ast.Var) and x.id.name == "x"
     assert isinstance(y, synr.ast.Var) and y.id.name == "y"
+
+    _, start_line = inspect.getsourcelines(foo)
+    assert gl.span.start_line == start_line + 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds support for parsing `nonlocal` and `global` statements. Not entirely sure how to handle parsing the string identifiers so I just parsed them to `Var`s with the same span as the whole statement.