### PR TITLE
fix function lineno

### DIFF
--- a/synr/ast.py
+++ b/synr/ast.py
@@ -47,9 +47,7 @@ class Span:
             end_col_offset = node.end_col_offset + 1  # type: ignore
         else:
             end_col_offset = node.col_offset + 2
-        return Span(
-            filename, lineno, node.col_offset + 1, end_lineno, end_col_offset
-        )
+        return Span(filename, lineno, node.col_offset + 1, end_lineno, end_col_offset)
 
     def merge(self, span: "Span") -> "Span":
         """Return the span starting from the beginning of the first span and

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -571,6 +571,8 @@ def test_decorators():
     module = to_ast(foo)
     fn = assert_one_fn(module, "foo")
     _, start_line = inspect.getsourcelines(foo)
+    assert fn.span.start_line == start_line + 1
+
     assert len(fn.decorators) == 1
     assert isinstance(fn.decorators[0], synr.ast.Var)
     assert fn.decorators[0].id.name == "A"
@@ -581,6 +583,8 @@ def test_decorators():
         assert fn.span.end_line == start_line + 7
 
     bar = fn.body.stmts[0]
+    assert bar.span.start_line == start_line + 4
+
     assert len(bar.decorators) == 2
 
     assert isinstance(bar.decorators[0], synr.ast.Var)


### PR DESCRIPTION
The ast.node.lineno for decorator depends on python versions. Example:
```python
@T.prim_func
def func(...):
    ...
```
`lineno` will be 1 (`@T.prim_func`)for Python3.6 and 3.7 but 2 (`def func`) for Python3.8+

This PR is a workaround for python <3.8 to create span correctly. 

BTW, the PR https://github.com/apache/tvm/pull/9115 is blocked by this bug.
