### PR TITLE
Enable Github Action for Python 3.10

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.6"
 attrs = "*"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
+pytest = "^6.2.4"
 black = { version = "^20.0", allow-prereleases = true }
 mypy = "^0.782"
 


### PR DESCRIPTION
Since Python 3.10 has released, it's better to add it into CI.