### PR TITLE
better parsing for type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ attrs = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
-black = { version = "^20.0", allow-prereleases = true }
+black = { version = "^21.10b0", allow-prereleases = true }
 mypy = "^0.782"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jared Roesch <jroesch@octoml.ai>", "Tristan Konolige <tkonolige@octo
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.2"
 attrs = "*"
 
 [tool.poetry.dev-dependencies]

--- a/synr/ast.py
+++ b/synr/ast.py
@@ -314,7 +314,7 @@ class TypeCall(Type):
     :code:`params[0]`.
     """
 
-    func_name: Union[Expr, BuiltinOp]
+    func_name: Type
     params: List[Type]
 
 
@@ -328,7 +328,7 @@ class TypeApply(Type):
     case, :code:`List` is the :code:`id`, and :code:`str` is :code:`params[0]`.
     """
 
-    id: Id
+    func_name: Type
     params: Sequence[Type]
 
 

--- a/synr/ast.py
+++ b/synr/ast.py
@@ -325,7 +325,8 @@ class TypeApply(Type):
     Example
     -------
     In :code:`x: List[str]`, :code:`List[str]` is a :code:`TypeCall`. In this
-    case, :code:`List` is the :code:`id`, and :code:`str` is :code:`params[0]`.
+    case, :code:`List` is the :code:`func_name`, and :code:`str` is
+    :code:`params[0]`.
     """
 
     func_name: Type

--- a/synr/ast.py
+++ b/synr/ast.py
@@ -314,7 +314,7 @@ class TypeCall(Type):
     :code:`params[0]`.
     """
 
-    func_name: Type
+    func_name: Union[Type, BuiltinOp]
     params: List[Type]
 
 

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -614,7 +614,7 @@ class Compiler:
                 return TypeCall(
                     expr.span,
                     expr.func_name.name,
-                    [self._expr2type(x) for x in expr.params]
+                    [self._expr2type(x) for x in expr.params],
                 )
             elif isinstance(expr.func_name, Expr):
                 return TypeCall(

--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -601,14 +601,20 @@ class Compiler:
                 self._expr2type(expr.end),
             )
         if isinstance(expr, Call):
-            if isinstance(expr.func_name, Op) and expr.func_name.name == BuiltinOp.Subscript:  # type: ignore
-                assert isinstance(
-                    expr.params[1], Tuple
-                ), f"Expected subscript call to have rhs of Tuple, but it is {type(expr.params[1])}"
-                return TypeApply(
+            if isinstance(expr.func_name, Op):
+                if expr.func_name.name == BuiltinOp.Subscript:  # type: ignore
+                    assert isinstance(
+                        expr.params[1], Tuple
+                    ), f"Expected subscript call to have rhs of Tuple, but it is {type(expr.params[1])}"
+                    return TypeApply(
+                        expr.span,
+                        self._expr2type(expr.params[0]),
+                        [self._expr2type(x) for x in expr.params[1].values],
+                    )
+                return TypeCall(
                     expr.span,
-                    self._expr2type(expr.params[0]),
-                    [self._expr2type(x) for x in expr.params[1].values],
+                    expr.func_name.name,
+                    [self._expr2type(x) for x in expr.params]
                 )
             elif isinstance(expr.func_name, Expr):
                 return TypeCall(

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -401,6 +401,7 @@ def func_type(x: X) -> Y:
     x: X[1] = 1
     x: test.X[Y] = 1
     x: test.X(Y) = 1
+    x: X + Y = 1
 
 
 def test_type():
@@ -435,6 +436,11 @@ def test_type():
     assert stmts[6].ty.func_name.object.id.name == "test"
     assert stmts[6].ty.func_name.field.name == "X"
     assert stmts[6].ty.params[0].id.name == "Y"
+
+    assert isinstance(stmts[7].ty, synr.ast.TypeCall)
+    assert stmts[7].ty.func_name == synr.ast.BuiltinOp.Add
+    assert stmts[7].ty.params[0].id.name == "X"
+    assert stmts[7].ty.params[1].id.name == "Y"
 
 
 def func_call():

--- a/tests/test_synr.py
+++ b/tests/test_synr.py
@@ -399,6 +399,8 @@ def func_type(x: X) -> Y:
     x: X[X, Y] = 1
     x: X[X:Y] = 1
     x: X[1] = 1
+    x: test.X[Y] = 1
+    x: test.X(Y) = 1
 
 
 def test_type():
@@ -414,13 +416,25 @@ def test_type():
     assert stmts[0].ty.field.name == "X"
 
     assert isinstance(stmts[1].ty, synr.ast.TypeApply)
-    assert stmts[1].ty.id.name == "X"
+    assert stmts[1].ty.func_name.id.name == "X"
     assert stmts[1].ty.params[0].id.name == "Y"
 
     assert isinstance(stmts[2].ty, synr.ast.TypeApply)
-    assert stmts[2].ty.id.name == "X"
+    assert stmts[2].ty.func_name.id.name == "X"
     assert stmts[2].ty.params[0].id.name == "X"
     assert stmts[2].ty.params[1].id.name == "Y"
+
+    assert isinstance(stmts[5].ty, synr.ast.TypeApply)
+    assert isinstance(stmts[5].ty.func_name, synr.ast.TypeAttr)
+    assert stmts[5].ty.func_name.object.id.name == "test"
+    assert stmts[5].ty.func_name.field.name == "X"
+    assert stmts[5].ty.params[0].id.name == "Y"
+
+    assert isinstance(stmts[6].ty, synr.ast.TypeCall)
+    assert isinstance(stmts[6].ty.func_name, synr.ast.TypeAttr)
+    assert stmts[6].ty.func_name.object.id.name == "test"
+    assert stmts[6].ty.func_name.field.name == "X"
+    assert stmts[6].ty.params[0].id.name == "Y"
 
 
 def func_call():


### PR DESCRIPTION
this adds support for parsing
```
x: foo.Bar[Baz]
x: foo.Bar(Baz)
x: Bar + Baz  # or any other BuiltinOp
```
The latter two examples are parsed to `TypeCall`s.

cc @tkonolige @shingjan 

note: breaking change since I renamed the `TypeApply`'s `id` field to `func_name` (didn't seem right to leave it as `id`)

fixes #16 