### PR TITLE
Fix jupyter inspect source

### DIFF
--- a/synr/compiler.py
+++ b/synr/compiler.py
@@ -727,10 +727,10 @@ def to_ast(
             else:
                 # make sure to preserve blank lines for correct spans
                 source = "\n".join([l[start_column:].rstrip() for l in lines])
-        mod = inspect.getmodule(program)
-        if mod is not None:
-            full_source = inspect.getsource(mod)
-        else:
+        try:
+            full_source, _ = inspect.findsource(program)
+            full_source = "".join(full_source)
+        except:
             full_source = source
     diagnostic_ctx.add_source(source_name, full_source)
     program_ast = py_ast.parse(source)


### PR DESCRIPTION
The Jupyter Notebook and Colab can not run TVMScript. errors:
```
/usr/lib/python3.7/inspect.py in getfile(object)
    645         if getattr(object, '__file__', None):
    646             return object.__file__
--> 647         raise TypeError('{!r} is a built-in module'.format(object))
    648     if isclass(object):
    649         if hasattr(object, '__module__'):

TypeError: <module '__main__'> is a built-in module
```

With this fix, it can be parsed correctly.

cc @tqchen @junrushao1994 